### PR TITLE
gwt UI: make links on welcome page open in new tab

### DIFF
--- a/oneswarm_gwt_ui/src/edu/washington/cs/oneswarm/ui/gwt/client/i18n/OSMessages.properties
+++ b/oneswarm_gwt_ui/src/edu/washington/cs/oneswarm/ui/gwt/client/i18n/OSMessages.properties
@@ -61,13 +61,13 @@ swarm_browser_welcome_defaults=(Subscribe to the default community server and se
 swarm_browser_welcome_button_default=Use default settings
 swarm_browser_welcome_manual_import=Advanced configuration
 swarm_browser_welcome_configuring=Configuring defaults...
-swarm_browser_welcome_no_friends_online_HTML=No friends are online. If you''ve recently added some friends or are just getting started, it may be a <a href=\"http://wiki.oneswarm.org/index.php/Connection_delay\">few minutes</a> before you can successfully connect to them.
+swarm_browser_welcome_no_friends_online_HTML=No friends are online. If you''ve recently added some friends or are just getting started, it may be a <a href=\"http://wiki.oneswarm.org/index.php/Connection_delay\" target=\"_blank\">few minutes</a> before you can successfully connect to them.
 swarm_browser_welcome_friends_online=Use the search box above to locate files. Your online friends are listed to the left. Having more peers online improves performance, so encourage your friends to try out OneSwarm!    
 swarm_browser_no_files_search_friends_HMTL=No files found matching filter. Press ENTER to <a href=\"#\">search the friend-to-friend network for ''<i>{0}</i>''</a>
 swarm_browser_no_friends_HTML=This view summarizes your friends. <a href=\"#addfriends\">Click to add friends</a>.
 swarm_browser_no_files_shared=This user is not currently sharing any files or has set you as a limited friend.
 # deprecated
-swarm_browser_welcome_message_HTML=<h2>Welcome to OneSwarm! <a href=\"#addfriends\">Add friends</a> to get started.</h2><br>If you''ve recently added some friends, it may be a <a href=\"http://wiki.oneswarm.org/index.php/Connection_delay\">few minutes</a> before you can successfully connect to them.<br>After connecting to friends, you can search the friend-to-friend network.<br>For an overview of how OneSwarm works, check out this <a href=\"http://oneswarm.cs.washington.edu/screencasts_overview.html#screencast_overview\">screencast</a>.
+swarm_browser_welcome_message_HTML=<h2>Welcome to OneSwarm! <a href=\"#addfriends\">Add friends</a> to get started.</h2><br>If you''ve recently added some friends, it may be a <a href=\"http://wiki.oneswarm.org/index.php/Connection_delay\" target=\"_blank\">few minutes</a> before you can successfully connect to them.<br>After connecting to friends, you can search the friend-to-friend network.<br>For an overview of how OneSwarm works, check out this <a href=\"http://oneswarm.cs.washington.edu/screencasts_overview.html#screencast_overview\" target=\"_blank\">screencast</a>.
 
 
 swarm_browser_more_actions=More actions...


### PR DESCRIPTION
So the user can still see her homepage while she waits for new friends.

Signed-off-by: Daniel Halperin dhalperi@cs.washington.edu
